### PR TITLE
Margotbligh patch 1

### DIFF
--- a/R/glycoAnnotate.R
+++ b/R/glycoAnnotate.R
@@ -161,6 +161,9 @@ glycoAnnotate <- function(data,
     }
   }
 
+  #set DT threads to avoid OMP errors
+  setDTthreads(threads = 1)
+
   #generate mzmin and mzmax columns in pred_table
   if(error_units == 'ppm'){
     ppm_to_mz = function(mz, noise){

--- a/inst/sugarMassesPredict.py
+++ b/inst/sugarMassesPredict.py
@@ -7,7 +7,6 @@ import math
 import re
 from operator import itemgetter
 import os
-os.environ['KMP_DUPLICATE_LIB_OK']='True'
 # suppress warnings
 pd.options.mode.chained_assignment = None  # default='warn'
 


### PR DESCRIPTION
Removed patchy line from python script about OMP error, and fixed 'source' of error in glycoAnnotate (setDTthreads to 1 instead of N)